### PR TITLE
Remove unnecessary dependencies and upgrade illuminate/database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
   "description": "Webman database",
   "require": {
     "workerman/webman-framework": "^2.1 || dev-master",
-    "illuminate/database": "^10.0 || ^11.0 || ^12.0",
-    "illuminate/http": "^10.0 || ^11.0 || ^12.0",
+    "illuminate/database": "^10.0 || ^11.0 || ^12.0 || ^13.0",
     "laravel/serializable-closure": "^1.0 || ^2.0"
   },
   "autoload": {


### PR DESCRIPTION
Remove "illuminate/http" because it is not used at all
Compatible with illuminate/database, supports version 13 series